### PR TITLE
Automatically install NavInstrument runways

### DIFF
--- a/Gamedata/KerbinSideRemasteredGapExtras/Patches/KerbinsideRemastered2.cfg
+++ b/Gamedata/KerbinSideRemasteredGapExtras/Patches/KerbinsideRemastered2.cfg
@@ -1,15 +1,12 @@
 // NAVInstruments Continued Runways For Kerbin Side Remastered GAP Extas
 // Author: Caerfinon 
 //
-//	To Install: 
-//  Copy this file to GameData/NAVInstruments/ModuleManagerCfgs and change the file extension to .cfg from .txt
-//  (it needs to be in the NAVInstruments directory to keep the correct display order of runways intact 
-//   if you leave it in this directory, then all the airstrips will show before the runways in the mod)
+// These runways are added FINAL so that they appear list after the stock and KSR Gap runways.
 //
 //-------------------------------------------------------------------
 // Aarash 
 //-------------------------------------------------------------------
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 	custom = False
 	ident = Aarash 09
 	shortID = RAS01
@@ -24,7 +21,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Aarash 27
@@ -44,7 +41,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 //-------------------------------------------------------------------
 // Auyuittuq
 //-------------------------------------------------------------------
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Auyuittuq 05
@@ -60,7 +57,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Auyuittuq 23
@@ -79,7 +76,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 //-------------------------------------------------------------------
 // Barald's Discovery
 //-------------------------------------------------------------------
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Barald's Discovery 16
@@ -95,7 +92,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Barald's Discovery 34
@@ -115,7 +112,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 //-------------------------------------------------------------------
 // Dinkelstein' Spirit
 //-------------------------------------------------------------------
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Dinkelstein's Spirit 09
@@ -131,7 +128,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Dinkelstein's Spirit 27
@@ -151,7 +148,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 //-------------------------------------------------------------------
 // Donfrod's Fortune
 //-------------------------------------------------------------------
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Donfrod's Fortune 05
@@ -167,7 +164,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Donfrod's Fortune 23
@@ -187,7 +184,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 //-------------------------------------------------------------------
 // Engineer's Luck
 //-------------------------------------------------------------------
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Engineer's Luck 18
@@ -203,7 +200,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Engineer's Luck 36
@@ -222,7 +219,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 //-------------------------------------------------------------------
 // Handen's Trail
 //-------------------------------------------------------------------
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Handen's Trial 12
@@ -238,7 +235,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Handen's Trial 30
@@ -257,7 +254,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 //-------------------------------------------------------------------
 // Kazer's Prize
 //-------------------------------------------------------------------
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Kazer's Prize 09
@@ -273,7 +270,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Kazer's Prize 27
@@ -292,7 +289,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 //-------------------------------------------------------------------
 // Kelrey's Fate
 //-------------------------------------------------------------------
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Kelrey's Fate 05
@@ -308,7 +305,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Kelreys Fate 23
@@ -328,7 +325,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 //-------------------------------------------------------------------
 // Krakeen's Bane
 //-------------------------------------------------------------------
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Kraken's Bane 01
@@ -344,7 +341,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Kraken's Bane 19
@@ -363,7 +360,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 //-------------------------------------------------------------------
 // Ludrey's Isolation
 //-------------------------------------------------------------------
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Ludrey's Isolation 12
@@ -379,7 +376,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Ludrey's Isolation 30
@@ -398,7 +395,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 //-------------------------------------------------------------------
 // Mako Sica
 //-------------------------------------------------------------------
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Mako Sica 14
@@ -414,7 +411,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Mako Sica 32
@@ -433,7 +430,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 //-------------------------------------------------------------------
 // Maufurt's Pride
 //-------------------------------------------------------------------
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Maufurt's Pride 04
@@ -449,7 +446,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Maufurt's Pride 22
@@ -468,7 +465,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 //-------------------------------------------------------------------
 // Pilot's Folly
 //-------------------------------------------------------------------
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Pilot's Folly 09
@@ -484,7 +481,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Pilot's Folly 27
@@ -504,7 +501,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 //-------------------------------------------------------------------
 // Rayzon's  Whim
 //-------------------------------------------------------------------
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Rayzon's Whim 17
@@ -520,7 +517,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Rayzon's Whim 35
@@ -540,7 +537,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 //-------------------------------------------------------------------
 // Ribster's Dream
 //-------------------------------------------------------------------
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Ribster's Dream 16
@@ -556,7 +553,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Ribster's Dream 34
@@ -575,7 +572,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 //-------------------------------------------------------------------
 // Scientist's Resignation
 //-------------------------------------------------------------------
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Scientist's Resign 07
@@ -591,7 +588,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Scientist's Resign 25
@@ -611,7 +608,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 //-------------------------------------------------------------------
 // Sulin's Odyssey
 //-------------------------------------------------------------------
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Sulin's Odyssey 09
@@ -627,7 +624,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Sulin's Odyssey 27
@@ -646,7 +643,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 //-------------------------------------------------------------------
 // Valdrin's Triumph
 //-------------------------------------------------------------------
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Valdrin's Triumph 14
@@ -662,7 +659,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Valdrin's Triumph 32
@@ -682,7 +679,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 //-------------------------------------------------------------------
 // Woomerang
 //-------------------------------------------------------------------
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Woomerang 05
@@ -698,7 +695,7 @@ Runway:NEEDS[KerbinSideRemasteredGapExtras]
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[KerbinSideRemasteredGapExtras]
+Runway:NEEDS[NavInstruments]:FINAL
 {
 	custom = False
 	ident = Woomerang 23

--- a/Gamedata/KerbinSideRemasteredGapExtras/Patches/KerbinsideRemastered2.cfg
+++ b/Gamedata/KerbinSideRemasteredGapExtras/Patches/KerbinsideRemastered2.cfg
@@ -7,6 +7,7 @@
 // Aarash 
 //-------------------------------------------------------------------
 Runway:NEEDS[NavInstruments]:FINAL
+{
 	custom = False
 	ident = Aarash 09
 	shortID = RAS01

--- a/Gamedata/KerbinSideRemasteredGapExtras/Patches/KerbinsideRemastered2.cfg
+++ b/Gamedata/KerbinSideRemasteredGapExtras/Patches/KerbinsideRemastered2.cfg
@@ -1,12 +1,10 @@
 // NAVInstruments Continued Runways For Kerbin Side Remastered GAP Extas
 // Author: Caerfinon 
 //
-// These runways are added FINAL so that they appear list after the stock and KSR Gap runways.
-//
 //-------------------------------------------------------------------
 // Aarash 
 //-------------------------------------------------------------------
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Aarash 09
@@ -22,7 +20,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Aarash 27
@@ -42,7 +40,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 //-------------------------------------------------------------------
 // Auyuittuq
 //-------------------------------------------------------------------
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Auyuittuq 05
@@ -58,7 +56,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Auyuittuq 23
@@ -77,7 +75,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 //-------------------------------------------------------------------
 // Barald's Discovery
 //-------------------------------------------------------------------
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Barald's Discovery 16
@@ -93,7 +91,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Barald's Discovery 34
@@ -113,7 +111,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 //-------------------------------------------------------------------
 // Dinkelstein' Spirit
 //-------------------------------------------------------------------
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Dinkelstein's Spirit 09
@@ -129,7 +127,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Dinkelstein's Spirit 27
@@ -149,7 +147,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 //-------------------------------------------------------------------
 // Donfrod's Fortune
 //-------------------------------------------------------------------
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Donfrod's Fortune 05
@@ -165,7 +163,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Donfrod's Fortune 23
@@ -185,7 +183,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 //-------------------------------------------------------------------
 // Engineer's Luck
 //-------------------------------------------------------------------
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Engineer's Luck 18
@@ -201,7 +199,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Engineer's Luck 36
@@ -220,7 +218,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 //-------------------------------------------------------------------
 // Handen's Trail
 //-------------------------------------------------------------------
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Handen's Trial 12
@@ -236,7 +234,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Handen's Trial 30
@@ -255,7 +253,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 //-------------------------------------------------------------------
 // Kazer's Prize
 //-------------------------------------------------------------------
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Kazer's Prize 09
@@ -271,7 +269,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Kazer's Prize 27
@@ -290,7 +288,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 //-------------------------------------------------------------------
 // Kelrey's Fate
 //-------------------------------------------------------------------
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Kelrey's Fate 05
@@ -306,7 +304,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Kelreys Fate 23
@@ -326,7 +324,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 //-------------------------------------------------------------------
 // Krakeen's Bane
 //-------------------------------------------------------------------
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Kraken's Bane 01
@@ -342,7 +340,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Kraken's Bane 19
@@ -361,7 +359,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 //-------------------------------------------------------------------
 // Ludrey's Isolation
 //-------------------------------------------------------------------
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Ludrey's Isolation 12
@@ -377,7 +375,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Ludrey's Isolation 30
@@ -396,7 +394,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 //-------------------------------------------------------------------
 // Mako Sica
 //-------------------------------------------------------------------
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Mako Sica 14
@@ -412,7 +410,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Mako Sica 32
@@ -431,7 +429,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 //-------------------------------------------------------------------
 // Maufurt's Pride
 //-------------------------------------------------------------------
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Maufurt's Pride 04
@@ -447,7 +445,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Maufurt's Pride 22
@@ -466,7 +464,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 //-------------------------------------------------------------------
 // Pilot's Folly
 //-------------------------------------------------------------------
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Pilot's Folly 09
@@ -482,7 +480,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Pilot's Folly 27
@@ -502,7 +500,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 //-------------------------------------------------------------------
 // Rayzon's  Whim
 //-------------------------------------------------------------------
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Rayzon's Whim 17
@@ -518,7 +516,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Rayzon's Whim 35
@@ -538,7 +536,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 //-------------------------------------------------------------------
 // Ribster's Dream
 //-------------------------------------------------------------------
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Ribster's Dream 16
@@ -554,7 +552,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Ribster's Dream 34
@@ -573,7 +571,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 //-------------------------------------------------------------------
 // Scientist's Resignation
 //-------------------------------------------------------------------
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Scientist's Resign 07
@@ -589,7 +587,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Scientist's Resign 25
@@ -609,7 +607,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 //-------------------------------------------------------------------
 // Sulin's Odyssey
 //-------------------------------------------------------------------
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Sulin's Odyssey 09
@@ -625,7 +623,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Sulin's Odyssey 27
@@ -644,7 +642,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 //-------------------------------------------------------------------
 // Valdrin's Triumph
 //-------------------------------------------------------------------
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Valdrin's Triumph 14
@@ -660,7 +658,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Valdrin's Triumph 32
@@ -680,7 +678,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 //-------------------------------------------------------------------
 // Woomerang
 //-------------------------------------------------------------------
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Woomerang 05
@@ -696,7 +694,7 @@ Runway:NEEDS[NavInstruments]:FINAL
 	middleMarkerDist = -1000
 	innerMarkerDist = -1000
 }
-Runway:NEEDS[NavInstruments]:FINAL
+Runway:NEEDS[NavInstruments]
 {
 	custom = False
 	ident = Woomerang 23


### PR DESCRIPTION
- If NavUtils Continued 1.12.x by linuxgurugamer (NavInstruments) is installed, then all the runways
  are automatically installed from Patches directory.
- Previously this had to be done manually.

Note: Due to the way ModuleManager and NavUtils works, the runways may well be added before major
runways, however the default in NavUtils is to only show runways within 100km, so this is not too
bad.